### PR TITLE
feat: implement multiply tool

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,7 +41,19 @@ def subtract(a: int, b: int) -> int:
 
 # TODO: Add a tool that returns the current date in ISO format
 
-# TODO: Add a multiply tool
+@mcp.tool()
+def multiply(a: int, b: int) -> int:
+    """Use this to multiply two numbers together.
+    
+    Args:
+        a: The first number.
+        b: The second number.
+    
+    Returns:
+        The product of the two numbers.
+    """
+    logger.info(f">>> Tool: 'multiply' called with numbers '{a}' and '{b}'")
+    return a * b
 
 # TODO: Add a tool that gets popular orders by state
 

--- a/test_server.py
+++ b/test_server.py
@@ -21,5 +21,10 @@ async def test_server():
         result = await client.call_tool("subtract", {"a": 10, "b": 3})
         print(f"<<< Result: {result[0].text}")
 
+        # Call multiply tool
+        print(">>>  Calling multiply tool for 5 * 5")
+        result = await client.call_tool("multiply", {"a": 5, "b": 5})
+        print(f"<<< Result: {result[0].text}")
+
 if __name__ == "__main__":
     asyncio.run(test_server())


### PR DESCRIPTION
This PR implements the `multiply` tool as requested in issue #1.

Changes:
- Added `multiply(a: int, b: int)` tool to `server.py`.
- Added test case for `multiply` in `test_server.py`.
- Removed the corresponding `TODO`.

Closes #1